### PR TITLE
fixes Python3.5 "yield in async function" errors

### DIFF
--- a/secret_handshake/boxstream.py
+++ b/secret_handshake/boxstream.py
@@ -58,12 +58,14 @@ class UnboxStream(object):
         self.nonce = inc_nonce(inc_nonce(self.nonce))
         return body
 
-    async def __aiter__(self):
-        while True:
-            data = await self.read()
-            if data is None:
-                return
-            yield data
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        data = await self.read()
+        if data is None:
+            raise StopAsyncIteration
+        return data
 
 
 class BoxStream(object):

--- a/secret_handshake/network.py
+++ b/secret_handshake/network.py
@@ -43,9 +43,15 @@ class SHSSocket(object):
     def disconnect(self):
         self.writer.close()
 
-    async def __aiter__(self):
-        async for msg in self.read_stream:
-            yield msg
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        msg = self.read_stream
+        if msg:
+            return msg
+        else:
+            raise StopAsyncIteration
 
     def on_connect(self, cb):
         self._on_connect = cb


### PR DESCRIPTION
fixes #4 but breaks tests.

I don't quite understand all this async stuff, or how to fix this test:

```
=========================================== ERRORS ============================================
_____________________ ERROR collecting secret_handshake/test_boxstream.py _____________________
.eggs/pytest-3.1.3-py3.5.egg/_pytest/python.py:408: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=importmode)
.eggs/py-1.4.34-py3.5.egg/py/_path/local.py:662: in pyimport
    __import__(modname)
E     File "/home/elektron/code/PySecretHandshake/secret_handshake/test_boxstream.py", line 74
E       assert [msg async for msg in unbox_stream] == [b'foo', b'foo', b'bar']
E                       ^
E   SyntaxError: invalid syntax
!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!
=================================== 1 error in 0.20 seconds ===================================
```